### PR TITLE
fix：修复评论显示不受站点全局控制以及文章或页面设置的控制

### DIFF
--- a/templates/main/article.html
+++ b/templates/main/article.html
@@ -89,7 +89,7 @@
         </div>
     </th:block>
 
-    <div class="card card-content" id="comment-wrapper" th:if="${pluginFinder.available('PluginCommentWidget')}">
+    <div class="card card-content" id="comment-wrapper" th:if="${(pluginFinder.available('PluginCommentWidget') && site.comment.enable) && (type == 'Post' ? post.spec.allowComment : singlePage.spec.allowComment)}">
         <h3 class="comment-title">评论</h3>
         <div class="widget-comment" th:data-id="${post.metadata.name}" th:data-target="${type}"></div>
     </div>


### PR DESCRIPTION
- 评论功能可启用前提要求，安装评论插件

- 评论功能受站点全局控制，若是站点关闭评论则文章或页面都无法打开
![image](https://github.com/mjsoftking/halo-theme-dream2.0/assets/23021469/9779e7b4-75d3-41c2-a626-bed5c3c69243)

- 站点开启评论时，评论功能受文章独立控制
![image](https://github.com/mjsoftking/halo-theme-dream2.0/assets/23021469/e2d97289-64af-488f-b45b-e9ec45c1c211)

- 站点开启评论时，评论功能受页面独立控制
![image](https://github.com/mjsoftking/halo-theme-dream2.0/assets/23021469/75c0376e-5a7f-46cd-aa02-60c3c00b3fe1)
